### PR TITLE
Simplify Y Combinator

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const T = a => b => b(a);
 const U = a => b => b(a(a)(b));
 const V = a => b => c => c(a)(b);
 const W = a => b => a(b)(b);
-const Y = a => (b => a(c => b(b)(c)))(b => a(c => b(b)(c)));
+const Y = a => (b => b(b))(b => a(c => b(b)(c)));
 ```
 
 Here are the tests:

--- a/index.es6.js
+++ b/index.es6.js
@@ -19,4 +19,4 @@ export const T = a => b => b(a);
 export const U = a => b => b(a(a)(b));
 export const V = a => b => c => c(a)(b);
 export const W = a => b => a(b)(b);
-export const Y = a => (b => a(c => b(b)(c)))(b => a(c => b(b)(c)));
+export const Y = a => (b => b(b))(b => a(c => b(b)(c)));


### PR DESCRIPTION
I was reading this post:

http://mvanier.livejournal.com/2897.html

Which has a very nice derivation of the Y combinator. Right at the end the author says:

> We end up with this definition of the strict Y combinator:

```
(define Y 
    (lambda (f)
      ((lambda (x) (f (lambda (y) ((x x) y))))
       (lambda (x) (f (lambda (y) ((x x) y)))))))
```

> This can also be written in the equivalent form:

```
(define Y 
    (lambda (f)
      ((lambda (x) (x x))
       (lambda (x) (f (lambda (y) ((x x) y)))))))
```

> Hopefully, you can see why this is equivalent.

Yeah, totally obvious :confounded:.

Anyway, it looks like your definition of Y could benefit from the same refactor.